### PR TITLE
chore: update doc page from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "cloudshell",
     "name_pretty": "Cloud Shell",
     "product_documentation": "https://cloud.google.com/shell/",
-    "client_documentation": "https://googleapis.dev/python/cloudshell/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/cloudshell/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages.