### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "cloudshell",
     "name_pretty": "Cloud Shell",
     "product_documentation": "https://cloud.google.com/shell/",
-    "client_documentation": "https://googleapis.dev/python/cloudshell/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/cloudshell/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ from your web browser.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-shell.svg
    :target: https://pypi.org/project/google-cloud-shell/
 .. _Cloud Shell: https://cloud.google.com/shell
-.. _Client Library Documentation: https://googleapis.dev/python/cloudshell/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/cloudshell/latest
 .. _Product Documentation:  https://cloud.google.com/shell/docs
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.